### PR TITLE
Feat/84 implement question post edit/park

### DIFF
--- a/app/api/posts/[id]/route.ts
+++ b/app/api/posts/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { PrismaPostRepository } from '@/backend/infra/repositories/prisma/PrismaPostRepository';
 import { GetPostByIdUseCase } from '@/backend/application/usecases/post/GetPostByIdUsecase';
 import { DeletePostUseCase } from '@/backend/application/usecases/post/DeletePostUseCase';
+import { UpdatePostUseCase, UpdatePostDto } from '@/backend/application/usecases/post/UpdatePostUseCase';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/app/api/auth/[...nextauth]/route';
 import prisma from '@/lib/prisma';
@@ -9,6 +10,7 @@ import prisma from '@/lib/prisma';
 const postRepository = new PrismaPostRepository(prisma);
 const getPostByIdUseCase = new GetPostByIdUseCase(postRepository);
 const deletePostUseCase = new DeletePostUseCase(postRepository);
+const updatePostUseCase = new UpdatePostUseCase(postRepository);
 
 export async function GET(request: NextRequest, { params }: { params: { id: string } }) {
   try {
@@ -28,6 +30,49 @@ export async function GET(request: NextRequest, { params }: { params: { id: stri
     return NextResponse.json(post);
   } catch (error) {
     console.error('Error fetching post:', error);
+    return NextResponse.json({ message: 'Internal server error' }, { status: 500 });
+  }
+}
+
+export async function PUT(request: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const { id } = await params;
+    const postId = parseInt(id);
+
+    if (isNaN(postId)) {
+      return NextResponse.json({ message: 'Invalid post ID' }, { status: 400 });
+    }
+
+    // 인증 확인
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.id) {
+      return NextResponse.json({ message: 'Unauthorized' }, { status: 401 });
+    }
+
+    // 요청 본문 파싱
+    const body = await request.json();
+    const dto: UpdatePostDto = {
+      title: body.title,
+      content: body.content,
+      contentHTML: body.contentHTML,
+      tags: body.tags || [],
+    };
+
+    // 게시물 수정
+    const updatedPost = await updatePostUseCase.execute(postId, session.user.id, dto);
+
+    return NextResponse.json(updatedPost, { status: 200 });
+  } catch (error: any) {
+    console.error('Error updating post:', error);
+
+    // 커스텀 에러 메시지 처리
+    if (error.message.includes('게시물을 찾을 수 없습니다')) {
+      return NextResponse.json({ message: error.message }, { status: 404 });
+    }
+    if (error.message.includes('권한이 없습니다')) {
+      return NextResponse.json({ message: error.message }, { status: 403 });
+    }
+
     return NextResponse.json({ message: 'Internal server error' }, { status: 500 });
   }
 }

--- a/app/api/questions/[id]/route.ts
+++ b/app/api/questions/[id]/route.ts
@@ -2,6 +2,10 @@ import { NextRequest, NextResponse } from 'next/server';
 import { PrismaQuestionRepository } from '@/backend/infra/repositories/prisma/PrismaQuestionRepository';
 import { GetQuestionByIdUseCase } from '@/backend/application/usecases/question/GetQuestionByIdUseCase';
 import { DeleteQuestionUseCase } from '@/backend/application/usecases/question/DeleteQuestionUseCase';
+import {
+  UpdateQuestionUseCase,
+  UpdateQuestionDto,
+} from '@/backend/application/usecases/question/UpdateQuestionUseCase';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/app/api/auth/[...nextauth]/route';
 import prisma from '@/lib/prisma';
@@ -9,6 +13,7 @@ import prisma from '@/lib/prisma';
 const questionRepository = new PrismaQuestionRepository(prisma);
 const getQuestionByIdUseCase = new GetQuestionByIdUseCase(questionRepository);
 const deleteQuestionUseCase = new DeleteQuestionUseCase(questionRepository);
+const updateQuestionUseCase = new UpdateQuestionUseCase(questionRepository);
 
 export async function GET(request: NextRequest, { params }: { params: { id: string } }) {
   try {
@@ -28,6 +33,52 @@ export async function GET(request: NextRequest, { params }: { params: { id: stri
     return NextResponse.json(question);
   } catch (error) {
     console.error('Error fetching question:', error);
+    return NextResponse.json({ message: 'Internal server error' }, { status: 500 });
+  }
+}
+
+export async function PUT(request: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const { id } = await params;
+    const questionId = parseInt(id);
+
+    if (isNaN(questionId)) {
+      return NextResponse.json({ message: 'Invalid question ID' }, { status: 400 });
+    }
+
+    // 인증 확인
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.id) {
+      return NextResponse.json({ message: 'Unauthorized' }, { status: 401 });
+    }
+
+    // 요청 본문 파싱
+    const body = await request.json();
+    const dto: UpdateQuestionDto = {
+      title: body.title,
+      content: body.content,
+      contentHTML: body.contentHTML,
+      tags: body.tags || [],
+    };
+
+    // 질문 수정
+    const updatedQuestion = await updateQuestionUseCase.execute(questionId, session.user.id, dto);
+
+    return NextResponse.json(updatedQuestion, { status: 200 });
+  } catch (error: any) {
+    console.error('Error updating question:', error);
+
+    // 커스텀 에러 메시지 처리
+    if (error.message.includes('질문을 찾을 수 없습니다')) {
+      return NextResponse.json({ message: error.message }, { status: 404 });
+    }
+    if (error.message.includes('권한이 없습니다')) {
+      return NextResponse.json({ message: error.message }, { status: 403 });
+    }
+    if (error.message.includes('답변이 작성되었으므로')) {
+      return NextResponse.json({ message: error.message }, { status: 400 });
+    }
+
     return NextResponse.json({ message: 'Internal server error' }, { status: 500 });
   }
 }

--- a/app/member/posts/[id]/edit/loading.tsx
+++ b/app/member/posts/[id]/edit/loading.tsx
@@ -1,0 +1,12 @@
+export default function Loading() {
+  return (
+    <div className="container max-w-4xl py-8">
+      <div className="flex items-center justify-center h-64">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary mx-auto mb-4"></div>
+          <p className="text-muted-foreground">게시물을 불러오는 중...</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/member/posts/[id]/edit/page.tsx
+++ b/app/member/posts/[id]/edit/page.tsx
@@ -1,0 +1,182 @@
+'use client';
+// UI 컴포넌트들
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Card, CardContent } from '@/components/ui/card';
+
+// tag 관련 컴포넌트들
+import { TagSelect } from '@/components/qna/TagSelect';
+import { Tag } from '@/backend/domain/entities/Tag';
+
+// 훅들
+import { useRef, useState, useEffect, Suspense } from 'react';
+import { useRouter, useParams } from 'next/navigation';
+import dynamic from 'next/dynamic';
+
+// editor 관련 데이터
+import { initialValue } from '@/app/member/qnas/write/editorInitialValue';
+import { SerializedEditorState } from 'lexical';
+import { getEditorHtmlFromJSON } from '@/lib/community/getEditorHtmlFromJSON';
+
+// 게시물 수정 함수
+import { updatePost } from '@/lib/queries/updatePost';
+import { getPost } from '@/lib/queries/getPost';
+
+// 게시물 수정시 데이터 캐시 무효화
+import { POSTS_QUERY_KEY } from '@/lib/constants/queryKeys';
+import { useQueryClient } from '@tanstack/react-query';
+
+// Editor 컴포넌트 SSR 비활성화
+const Editor = dynamic(() => import('@/components/blocks/editor-y/editor').then((mod) => mod.Editor), {
+  ssr: false,
+  loading: () => <div className="h-72 w-full animate-pulse rounded-lg bg-muted" />,
+});
+
+// 게시물 편집 페이지
+export default function EditPage() {
+  // 태그 선택 상태
+  const [tags, setTags] = useState<Tag[]>([]);
+  // 제목 입력 상태
+  const title = useRef<HTMLInputElement>(null);
+  // editor 상태
+  const editorState = useRef<SerializedEditorState>(initialValue);
+  // 로딩 상태
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  // 라우터, 쿼리 클라이언트, 파라미터
+  const router = useRouter();
+  const params = useParams();
+  const queryClient = useQueryClient();
+  const postId = params.id as string;
+
+  // 기존 게시물 데이터 로딩
+  useEffect(() => {
+    const loadPost = async () => {
+      try {
+        const post = await getPost(postId);
+
+        // 폼에 기존 데이터 설정
+        if (title.current) {
+          title.current.value = post.title;
+        }
+
+        // 에디터 상태 설정
+        if (post.content) {
+          editorState.current = post.content;
+        }
+
+        // 태그 설정
+        if (post.tags) {
+          setTags(post.tags);
+        }
+
+        setIsLoading(false);
+      } catch (error) {
+        console.error('Error loading post:', error);
+        alert('게시물을 불러오는데 실패했습니다.');
+        router.back();
+      }
+    };
+
+    if (postId) {
+      loadPost();
+    }
+  }, [postId, router]);
+
+  // 게시물 수정 함수
+  const handleSubmit = async (e: React.FormEvent) => {
+    const htmlContent = getEditorHtmlFromJSON(editorState.current);
+
+    // 폼 제출 방지
+    e.preventDefault();
+
+    if (isSubmitting) return;
+
+    setIsSubmitting(true);
+    try {
+      // 게시물 수정 요청
+      const result = await updatePost(parseInt(postId), {
+        title: title.current?.value || '',
+        content: editorState.current,
+        contentHTML: htmlContent,
+        tags,
+      });
+
+      console.log('Post updated:', result);
+
+      // 무한 쿼리 완전히 리셋하고 새로고침
+      await queryClient.resetQueries({ queryKey: POSTS_QUERY_KEY });
+
+      // 수정된 게시물 상세 페이지로 이동
+      router.push(`/community/posts/${postId}`);
+    } catch (error: any) {
+      console.error('Error updating post:', error);
+      alert(error.message || '게시물 수정에 실패했습니다.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="container max-w-4xl py-8">
+        <div className="flex items-center justify-center h-64">
+          <div className="text-center">
+            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary mx-auto mb-4"></div>
+            <p className="text-muted-foreground">게시물을 불러오는 중...</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container max-w-4xl py-8">
+      <div className="flex flex-col gap-6">
+        <div className="flex flex-col gap-2">
+          <h1 className="text-3xl font-bold">게시물 수정</h1>
+          <p className="text-muted-foreground">게시물 내용을 수정하세요. (댓글이 있어도 수정 가능합니다)</p>
+        </div>
+        <form onSubmit={handleSubmit} className="flex flex-col gap-6">
+          <Card>
+            <CardContent className="p-6">
+              <div className="flex flex-col gap-4">
+                <div className="flex flex-col gap-2">
+                  <label htmlFor="title" className="text-sm font-medium">
+                    제목
+                  </label>
+                  <Input id="title" ref={title} placeholder="제목을 입력하세요" required />
+                </div>
+
+                <div className="flex flex-col gap-2">
+                  <label className="text-sm font-medium">태그</label>
+                  <TagSelect selectedTags={tags} onTagsChange={setTags} />
+                </div>
+
+                <div className="flex flex-col gap-2">
+                  <label className="text-sm font-medium">내용</label>
+                  <Suspense fallback={<div className="h-72 w-full animate-pulse rounded-lg bg-muted" />}>
+                    <Editor
+                      editorSerializedState={editorState.current}
+                      onSerializedChange={(value) => (editorState.current = value)}
+                    />
+                  </Suspense>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          <div className="flex justify-end gap-2">
+            <Button type="button" variant="outline" onClick={() => router.back()}>
+              취소
+            </Button>
+            <Button type="submit" disabled={isSubmitting}>
+              {isSubmitting ? '수정 중...' : '수정하기'}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/app/member/qnas/[id]/edit/loading.tsx
+++ b/app/member/qnas/[id]/edit/loading.tsx
@@ -1,0 +1,12 @@
+export default function Loading() {
+  return (
+    <div className="container max-w-4xl py-8">
+      <div className="flex items-center justify-center h-64">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary mx-auto mb-4"></div>
+          <p className="text-muted-foreground">질문을 불러오는 중...</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/member/qnas/[id]/edit/page.tsx
+++ b/app/member/qnas/[id]/edit/page.tsx
@@ -1,0 +1,182 @@
+'use client';
+// UI 컴포넌트들
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Card, CardContent } from '@/components/ui/card';
+
+// tag 관련 컴포넌트들
+import { TagSelect } from '@/components/qna/TagSelect';
+import { Tag } from '@/backend/domain/entities/Tag';
+
+// 훅들
+import { useRef, useState, useEffect, Suspense } from 'react';
+import { useRouter, useParams } from 'next/navigation';
+import dynamic from 'next/dynamic';
+
+// editor 관련 데이터
+import { initialValue } from '@/app/member/qnas/write/editorInitialValue';
+import { SerializedEditorState } from 'lexical';
+import { getEditorHtmlFromJSON } from '@/lib/community/getEditorHtmlFromJSON';
+
+// 질문 수정 함수
+import { updateQuestion } from '@/lib/queries/updateQuestion';
+import { getQuestion } from '@/lib/queries/getQuestion';
+
+// 질문 수정시 데이터 캐시 무효화
+import { QUESTIONS_QUERY_KEY } from '@/lib/constants/queryKeys';
+import { useQueryClient } from '@tanstack/react-query';
+
+// Editor 컴포넌트 SSR 비활성화
+const Editor = dynamic(() => import('@/components/blocks/editor-x/editor').then((mod) => mod.Editor), {
+  ssr: false,
+  loading: () => <div className="h-72 w-full animate-pulse rounded-lg bg-muted" />,
+});
+
+// 질문 편집 페이지
+export default function EditPage() {
+  // 태그 선택 상태
+  const [tags, setTags] = useState<Tag[]>([]);
+  // 제목 입력 상태
+  const title = useRef<HTMLInputElement>(null);
+  // editor 상태
+  const editorState = useRef<SerializedEditorState>(initialValue);
+  // 로딩 상태
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  // 라우터, 쿼리 클라이언트, 파라미터
+  const router = useRouter();
+  const params = useParams();
+  const queryClient = useQueryClient();
+  const questionId = params.id as string;
+
+  // 기존 질문 데이터 로딩
+  useEffect(() => {
+    const loadQuestion = async () => {
+      try {
+        const question = await getQuestion(questionId);
+
+        // 폼에 기존 데이터 설정
+        if (title.current) {
+          title.current.value = question.title;
+        }
+
+        // 에디터 상태 설정
+        if (question.content) {
+          editorState.current = question.content;
+        }
+
+        // 태그 설정
+        if (question.tags) {
+          setTags(question.tags);
+        }
+
+        setIsLoading(false);
+      } catch (error) {
+        console.error('Error loading question:', error);
+        alert('질문을 불러오는데 실패했습니다.');
+        router.back();
+      }
+    };
+
+    if (questionId) {
+      loadQuestion();
+    }
+  }, [questionId, router]);
+
+  // 질문 수정 함수
+  const handleSubmit = async (e: React.FormEvent) => {
+    const htmlContent = getEditorHtmlFromJSON(editorState.current);
+
+    // 폼 제출 방지
+    e.preventDefault();
+
+    if (isSubmitting) return;
+
+    setIsSubmitting(true);
+    try {
+      // 질문 수정 요청
+      const result = await updateQuestion(parseInt(questionId), {
+        title: title.current?.value || '',
+        content: editorState.current,
+        contentHTML: htmlContent,
+        tags,
+      });
+
+      console.log('Question updated:', result);
+
+      // 무한 쿼리 완전히 리셋하고 새로고침
+      await queryClient.resetQueries({ queryKey: QUESTIONS_QUERY_KEY });
+
+      // 수정된 질문 상세 페이지로 이동
+      router.push(`/community/qnas/${questionId}`);
+    } catch (error: any) {
+      console.error('Error updating question:', error);
+      alert(error.message || '질문 수정에 실패했습니다.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="container max-w-4xl py-8">
+        <div className="flex items-center justify-center h-64">
+          <div className="text-center">
+            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary mx-auto mb-4"></div>
+            <p className="text-muted-foreground">질문을 불러오는 중...</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container max-w-4xl py-8">
+      <div className="flex flex-col gap-6">
+        <div className="flex flex-col gap-2">
+          <h1 className="text-3xl font-bold">질문 수정</h1>
+          <p className="text-muted-foreground">질문 내용을 수정하세요. (답변이 있는 질문은 수정할 수 없습니다)</p>
+        </div>
+        <form onSubmit={handleSubmit} className="flex flex-col gap-6">
+          <Card>
+            <CardContent className="p-6">
+              <div className="flex flex-col gap-4">
+                <div className="flex flex-col gap-2">
+                  <label htmlFor="title" className="text-sm font-medium">
+                    제목
+                  </label>
+                  <Input id="title" ref={title} placeholder="제목을 입력하세요" required />
+                </div>
+
+                <div className="flex flex-col gap-2">
+                  <label className="text-sm font-medium">태그</label>
+                  <TagSelect selectedTags={tags} onTagsChange={setTags} />
+                </div>
+
+                <div className="flex flex-col gap-2">
+                  <label className="text-sm font-medium">내용</label>
+                  <Suspense fallback={<div className="h-72 w-full animate-pulse rounded-lg bg-muted" />}>
+                    <Editor
+                      editorSerializedState={editorState.current}
+                      onSerializedChange={(value) => (editorState.current = value)}
+                    />
+                  </Suspense>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          <div className="flex justify-end gap-2">
+            <Button type="button" variant="outline" onClick={() => router.back()}>
+              취소
+            </Button>
+            <Button type="submit" disabled={isSubmitting}>
+              {isSubmitting ? '수정 중...' : '수정하기'}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/backend/application/usecases/post/UpdatePostUseCase.ts
+++ b/backend/application/usecases/post/UpdatePostUseCase.ts
@@ -1,0 +1,47 @@
+import { PostRepository } from '@/backend/domain/repositories/PostRepository';
+import { Post } from '@/backend/domain/entities/Post';
+import { Tag } from '@/backend/domain/entities/Tag';
+
+export interface UpdatePostDto {
+  title: string;
+  content: any;
+  contentHTML: string;
+  tags: Tag[];
+}
+
+export class UpdatePostUseCase {
+  constructor(private postRepository: PostRepository) {}
+
+  async execute(postId: number, userId: string, dto: UpdatePostDto): Promise<Post> {
+    // 게시물 존재 여부 확인
+    const existingPost = await this.postRepository.findById(postId);
+    if (!existingPost) {
+      throw new Error('게시물을 찾을 수 없습니다.');
+    }
+
+    // 게시물 작성자 확인
+    if (existingPost.userId !== userId) {
+      throw new Error('게시물을 수정할 권한이 없습니다.');
+    }
+
+    // Post는 댓글이 있어도 수정 가능 (Question과 다른 정책)
+
+    // 게시물 수정
+    const updatedPost = new Post({
+      id: postId,
+      title: dto.title,
+      content: dto.content,
+      contentHTML: dto.contentHTML,
+      userId: existingPost.userId,
+      createdAt: existingPost.createdAt,
+      updatedAt: new Date(),
+    });
+
+    const result = await this.postRepository.update(postId, updatedPost);
+
+    // 태그 업데이트 (기존 태그 삭제 후 새 태그 추가)
+    await this.postRepository.updateTags(postId, dto.tags);
+
+    return result;
+  }
+}

--- a/backend/application/usecases/question/UpdateQuestionUseCase.ts
+++ b/backend/application/usecases/question/UpdateQuestionUseCase.ts
@@ -1,0 +1,51 @@
+import { QuestionRepository } from '@/backend/domain/repositories/QuestionRepository';
+import { Question } from '@/backend/domain/entities/Question';
+import { Tag } from '@/backend/domain/entities/Tag';
+
+export interface UpdateQuestionDto {
+  title: string;
+  content: any;
+  contentHTML: string;
+  tags: Tag[];
+}
+
+export class UpdateQuestionUseCase {
+  constructor(private questionRepository: QuestionRepository) {}
+
+  async execute(questionId: number, userId: string, dto: UpdateQuestionDto): Promise<Question> {
+    // 질문 존재 여부 확인
+    const existingQuestion = await this.questionRepository.findById(questionId);
+    if (!existingQuestion) {
+      throw new Error('질문을 찾을 수 없습니다.');
+    }
+
+    // 질문 작성자 확인
+    if (existingQuestion.userId !== userId) {
+      throw new Error('질문을 수정할 권한이 없습니다.');
+    }
+
+    // 답변 존재 여부 확인 (답변이 있으면 수정 불가)
+    const hasAnswers = await this.questionRepository.hasAnswers(questionId);
+    if (hasAnswers) {
+      throw new Error('이미 답변이 작성되었으므로 수정이 불가능합니다.');
+    }
+
+    // 질문 수정
+    const updatedQuestion = new Question({
+      id: questionId,
+      title: dto.title,
+      content: dto.content,
+      contentHTML: dto.contentHTML,
+      userId: existingQuestion.userId,
+      createdAt: existingQuestion.createdAt,
+      updatedAt: new Date(),
+    });
+
+    const result = await this.questionRepository.update(questionId, updatedQuestion);
+
+    // 태그 업데이트 (기존 태그 삭제 후 새 태그 추가)
+    await this.questionRepository.updateTags(questionId, dto.tags);
+
+    return result;
+  }
+}

--- a/backend/domain/repositories/PostRepository.ts
+++ b/backend/domain/repositories/PostRepository.ts
@@ -17,5 +17,7 @@ export interface PostRepository {
   findById(id: number): Promise<Post | null>;
   findAll(params: PaginationParams): Promise<PaginatedPosts>;
   addTags(postId: number, tags: Tag[]): Promise<void>;
+  updateTags(postId: number, tags: Tag[]): Promise<void>;
+  update(id: number, post: Post): Promise<Post>;
   delete(id: number): Promise<void>;
 }

--- a/backend/domain/repositories/questionRepository.ts
+++ b/backend/domain/repositories/questionRepository.ts
@@ -17,6 +17,7 @@ export interface QuestionRepository {
   findById(id: number): Promise<Question | null>;
   findAll(params: PaginationParams): Promise<PaginatedQuestions>;
   addTags(questionId: number, tags: Tag[]): Promise<void>;
+  updateTags(questionId: number, tags: Tag[]): Promise<void>;
   delete(id: number, userId: string): Promise<void>;
   update(id: number, question: Question): Promise<Question>;
   hasAnswers(id: number): Promise<boolean>;

--- a/backend/infra/repositories/prisma/PrismaPostRepository.ts
+++ b/backend/infra/repositories/prisma/PrismaPostRepository.ts
@@ -176,6 +176,45 @@ export class PrismaPostRepository implements PostRepository {
     };
   }
 
+  async updateTags(postId: number, tags: Tag[]): Promise<void> {
+    // 기존 태그 연결 삭제
+    await this.prisma.posts_tags.deleteMany({
+      where: { postId: postId },
+    });
+
+    // 새 태그 연결 추가
+    if (tags.length > 0) {
+      await this.prisma.posts_tags.createMany({
+        data: tags.map((t) => ({
+          postId: postId,
+          tagId: t.id,
+        })),
+      });
+    }
+  }
+
+  async update(id: number, post: Post): Promise<Post> {
+    const updated = await this.prisma.posts.update({
+      where: { id },
+      data: {
+        title: post.title,
+        content: post.content,
+        contentHTML: post.contentHTML,
+        updatedAt: new Date(),
+      },
+    });
+
+    return new Post({
+      id: updated.id,
+      title: updated.title,
+      content: updated.content,
+      contentHTML: updated.contentHTML,
+      createdAt: updated.createdAt,
+      updatedAt: updated.updatedAt,
+      userId: updated.userId,
+    });
+  }
+
   async delete(id: number): Promise<void> {
     // 소프트 삭제로 구현 (deletedAt 필드 설정)
     await this.prisma.posts.update({

--- a/backend/infra/repositories/prisma/PrismaQuestionRepository.ts
+++ b/backend/infra/repositories/prisma/PrismaQuestionRepository.ts
@@ -219,6 +219,7 @@ export class PrismaQuestionRepository implements QuestionRepository {
         title: question.title,
         content: question.content,
         contentHTML: question.contentHTML,
+        updatedAt: new Date(),
       },
     });
 

--- a/backend/infra/repositories/prisma/PrismaQuestionRepository.ts
+++ b/backend/infra/repositories/prisma/PrismaQuestionRepository.ts
@@ -232,4 +232,21 @@ export class PrismaQuestionRepository implements QuestionRepository {
       userId: updated.userId,
     });
   }
+
+  async updateTags(questionId: number, tags: Tag[]): Promise<void> {
+    // 기존 태그 연결 삭제
+    await this.prisma.qna_tags.deleteMany({
+      where: { qnaId: questionId },
+    });
+
+    // 새 태그 연결 추가
+    if (tags.length > 0) {
+      await this.prisma.qna_tags.createMany({
+        data: tags.map((t) => ({
+          qnaId: questionId,
+          tagId: t.id,
+        })),
+      });
+    }
+  }
 }

--- a/components/post/PostOptionDropdown.tsx
+++ b/components/post/PostOptionDropdown.tsx
@@ -58,7 +58,7 @@ export function PostOptionDropdown({ postId }: PostOptionDropdownProps) {
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
-        <DropdownMenuItem>
+        <DropdownMenuItem onClick={() => router.push(`/member/posts/${postId}/edit`)}>
           <Edit className="h-3 w-3 mr-2" />
           수정
         </DropdownMenuItem>

--- a/components/qna/QuestionOptionDropdown.tsx
+++ b/components/qna/QuestionOptionDropdown.tsx
@@ -65,7 +65,7 @@ export function QuestionOptionDropdown({ questionId, answerCount = 0 }: Question
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
-        <DropdownMenuItem>
+        <DropdownMenuItem onClick={() => router.push(`/member/qnas/${questionId}/edit`)}>
           <Edit className="h-4 w-4 mr-2" />
           수정
         </DropdownMenuItem>

--- a/lib/queries/updatePost.ts
+++ b/lib/queries/updatePost.ts
@@ -1,0 +1,36 @@
+import { SerializedEditorState } from 'lexical';
+import { Tag } from '@/backend/domain/entities/Tag';
+
+export interface UpdatePostRequest {
+  title: string;
+  content: SerializedEditorState;
+  contentHTML: string;
+  tags: Tag[];
+}
+
+export interface UpdatePostResponse {
+  id: number;
+  title: string;
+  content: SerializedEditorState;
+  contentHTML: string;
+  tags: Tag[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export const updatePost = async (id: number, data: UpdatePostRequest): Promise<UpdatePostResponse> => {
+  const response = await fetch(`/api/posts/${id}`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(data),
+  });
+
+  if (!response.ok) {
+    const errorData = await response.json();
+    throw new Error(errorData.message || '게시물 수정에 실패했습니다.');
+  }
+
+  return response.json();
+};

--- a/lib/queries/updateQuestion.ts
+++ b/lib/queries/updateQuestion.ts
@@ -1,0 +1,36 @@
+import { SerializedEditorState } from 'lexical';
+import { Tag } from '@/backend/domain/entities/Tag';
+
+export interface UpdateQuestionRequest {
+  title: string;
+  content: SerializedEditorState;
+  contentHTML: string;
+  tags: Tag[];
+}
+
+export interface UpdateQuestionResponse {
+  id: number;
+  title: string;
+  content: SerializedEditorState;
+  contentHTML: string;
+  tags: Tag[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export const updateQuestion = async (id: number, data: UpdateQuestionRequest): Promise<UpdateQuestionResponse> => {
+  const response = await fetch(`/api/questions/${id}`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(data),
+  });
+
+  if (!response.ok) {
+    const errorData = await response.json();
+    throw new Error(errorData.message || '질문 수정에 실패했습니다.');
+  }
+
+  return response.json();
+};


### PR DESCRIPTION
# Pull Request

## 🔢 Issue Number

<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요. -->
<!-- 예시 : resolves #1 -->

resolves #84

## 📝 요약

Question과 Post의 수정 기능을 완전히 구현했습니다. 백엔드에서는 UseCase와 Repository 패턴을 활용하여 수정 로직을 구현하고, 프론트엔드에서는 기존 작성 페이지 구조를 재사용하여 일관된 UX를 제공합니다. Question과 Post의 서로 다른 수정 정책(답변/댓글 존재 시 처리)을 적절히 반영했습니다.

## 🛠️ PR 유형

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📋 변경사항 상세 설명

### 🔧 백엔드 구현
**Question 수정 기능:**
- `UpdateQuestionUseCase` 구현 (권한 확인, 답변 존재 시 수정 불가 정책)
- `QuestionRepository`에 `updateTags` 메서드 추가
- `PrismaQuestionRepository`에 태그 업데이트 로직 구현 (기존 태그 삭제 후 새 태그 추가)
- `PUT /api/questions/[id]` 엔드포인트 구현

**Post 수정 기능:**
- `UpdatePostUseCase` 구현 (권한 확인, 댓글 존재 여부와 관계없이 수정 가능)
- `PostRepository`에 `update`, `updateTags` 메서드 추가
- `PrismaPostRepository`에 수정 및 태그 업데이트 로직 구현
- `PUT /api/posts/[id]` 엔드포인트 구현

### 🎨 프론트엔드 구현
**Question 수정:**
- `updateQuestion` 함수 구현 (`lib/queries/updateQuestion.ts`)
- 편집 페이지 구성 (`/member/qnas/[id]/edit`)
- 기존 질문 데이터 로딩하여 폼 초기값 설정
- `QuestionOptionDropdown` 수정 버튼에 편집 페이지 라우팅 연결

**Post 수정:**
- `updatePost` 함수 구현 (`lib/queries/updatePost.ts`)
- 편집 페이지 구성 (`/member/posts/[id]/edit`)
- 기존 게시물 데이터 로딩하여 폼 초기값 설정
- `PostOptionDropdown` 수정 버튼에 편집 페이지 라우팅 연결

### 🐛 버그 수정
- Question 수정 시 `updatedAt` 필드 업데이트 누락 수정

### 🔑 주요 정책 차이
| 기능 | Question | Post |
|------|----------|------|
| **수정 제한** | 답변 있으면 수정 불가 | 댓글 있어도 수정 가능 |
| **에디터** | editor-x | editor-y |
| **권한** | 작성자 본인만 | 작성자 본인만 |
| **태그** | 완전 교체 | 완전 교체 |

## 🖼️ 스크린샷 및 데모

<!-- Question/Post 수정 페이지 스크린샷 또는 수정 기능 동작 데모 영상 첨부 권장 -->

## 👀 리뷰어

<!-- 예시: @username -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [ ] 필요한 경우 문서를 업데이트했습니다.
- [x] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [ ] 브랜치가 최신 상태의 메인 브랜치와 병합 가능합니다.

## 📢 특이사항

- **수정 정책 차이**: Question은 답변이 있으면 수정할 수 없지만, Post는 댓글이 있어도 수정 가능
- **react-query 미사용**: 기존 삭제 기능과 일관성을 위해 순수 함수 기반으로 구현
- **기존 UI 재사용**: 작성 페이지와 동일한 구조로 일관된 사용자 경험 제공
- **태그 처리**: 수정 시 기존 태그를 모두 삭제한 후 새 태그로 완전 교체
- **캐시 무효화**: 수정 완료 후 적절한 쿼리 캐시 리셋 적용
- **에러 처리**: 권한 오류, 수정 불가 상황 등에 대한 적절한 사용자 피드백 제공