### PR TITLE
게시물/질문 수정 시 제목 필드 초기값 설정 오류 해결

### DIFF
--- a/app/member/posts/[id]/edit/page.tsx
+++ b/app/member/posts/[id]/edit/page.tsx
@@ -37,7 +37,9 @@ export default function EditPage() {
   // 태그 선택 상태
   const [tags, setTags] = useState<Tag[]>([]);
   // 제목 입력 상태
-  const title = useRef<HTMLInputElement>(null);
+  const [title, setTitle] = useState<string | null>(null);
+  // const title = useRef<HTMLInputElement>(null);
+
   // editor 상태
   const editorState = useRef<SerializedEditorState>(initialValue);
   // 로딩 상태
@@ -57,8 +59,8 @@ export default function EditPage() {
         const post = await getPost(postId);
 
         // 폼에 기존 데이터 설정
-        if (title.current) {
-          title.current.value = post.title;
+        if (post.title) {
+          setTitle(post.title);
         }
 
         // 에디터 상태 설정
@@ -97,12 +99,11 @@ export default function EditPage() {
     try {
       // 게시물 수정 요청
       const result = await updatePost(parseInt(postId), {
-        title: title.current?.value || '',
+        title: title || '',
         content: editorState.current,
         contentHTML: htmlContent,
         tags,
       });
-
 
       // 무한 쿼리 완전히 리셋하고 새로고침
       await queryClient.resetQueries({ queryKey: POSTS_QUERY_KEY });
@@ -145,7 +146,13 @@ export default function EditPage() {
                   <label htmlFor="title" className="text-sm font-medium">
                     제목
                   </label>
-                  <Input id="title" ref={title} placeholder="제목을 입력하세요" required />
+                  <Input
+                    id="title"
+                    value={title || ''}
+                    onChange={(e) => setTitle(e.target.value)}
+                    placeholder="제목을 입력하세요"
+                    required
+                  />
                 </div>
 
                 <div className="flex flex-col gap-2">

--- a/app/member/qnas/[id]/edit/page.tsx
+++ b/app/member/qnas/[id]/edit/page.tsx
@@ -37,7 +37,9 @@ export default function EditPage() {
   // 태그 선택 상태
   const [tags, setTags] = useState<Tag[]>([]);
   // 제목 입력 상태
-  const title = useRef<HTMLInputElement>(null);
+  // const title = useRef<HTMLInputElement>(null);
+  const [title, setTitle] = useState<string | null>(null);
+
   // editor 상태
   const editorState = useRef<SerializedEditorState>(initialValue);
   // 로딩 상태
@@ -57,8 +59,8 @@ export default function EditPage() {
         const question = await getQuestion(questionId);
 
         // 폼에 기존 데이터 설정
-        if (title.current) {
-          title.current.value = question.title;
+        if (question.title) {
+          setTitle(question.title);
         }
 
         // 에디터 상태 설정
@@ -70,8 +72,6 @@ export default function EditPage() {
         if (question.tags) {
           setTags(question.tags);
         }
-
-        if (title.current && question.title) title.current.value = question.title;
 
         setIsLoading(false);
       } catch (error) {
@@ -99,7 +99,7 @@ export default function EditPage() {
     try {
       // 질문 수정 요청
       const result = await updateQuestion(parseInt(questionId), {
-        title: title.current?.value || '',
+        title: title || '',
         content: editorState.current,
         contentHTML: htmlContent,
         tags,
@@ -146,7 +146,13 @@ export default function EditPage() {
                   <label htmlFor="title" className="text-sm font-medium">
                     제목
                   </label>
-                  <Input id="title" ref={title} placeholder="제목을 입력하세요" required />
+                  <Input
+                    id="title"
+                    value={title || ''}
+                    onChange={(e) => setTitle(e.target.value)}
+                    placeholder="제목을 입력하세요"
+                    required
+                  />
                 </div>
 
                 <div className="flex flex-col gap-2">


### PR DESCRIPTION
# Pull Request

## 🔢 Issue Number

<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요. -->
<!-- 예시 : resolves #1 -->

resolves #124 

## 📝 요약

게시물 및 질문 수정 페이지(`app/member/posts/[id]/edit/page.tsx`, `app/member/qnas/[id]/edit/page.tsx`)에서 제목 `Input` 필드에 기존 데이터의 제목이 기본값으로 설정되지 않던 버그를 수정합니다. `useRef`를 사용하여 DOM을 직접 조작하던 방식에서 `useState`를 사용한 제어 컴포넌트 방식으로 변경하여 React의 상태 관리 흐름에 맞게 수정했습니다.

## 🛠️ PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📋 변경사항 상세 설명

- **문제 원인:** 기존에는 `useRef`를 사용하여 제목 `Input` 필드의 DOM 요소에 직접 접근하고 `useEffect` 내에서 `.current.value`를 설정하여 초기값을 부여하려고 했습니다. 이 방식은 React가 상태 변화를 감지하고 리렌더링하는 방식과 어긋나, `Input` 컴포넌트의 `defaultValue`나 `value` prop이 제대로 작동하지 않았습니다.
- **해결 방법:**
    - 제목 상태 관리를 위해 `useRef` 대신 `useState` (예: `const [title, setTitle] = useState<string | null>(null);`)를 도입했습니다.
    - `useEffect` 내에서 비동기적으로 데이터를 불러온 후, `setTitle(loadedData.title)`을 호출하여 상태를 업데이트합니다.
    - `Input` 컴포넌트에 `value={title || ''}` prop을 설정하고, `onChange={(e) => setTitle(e.target.value)}` 핸들러를 추가하여 제어 컴포넌트로 만들었습니다.
- **결과:** 이 변경을 통해 수정 페이지 로드 시 기존 제목이 `Input` 필드에 정상적으로 표시되며, 사용자 입력에 따라 상태가 올바르게 업데이트됩니다.
- **대상 파일:**
    - `app/member/posts/[id]/edit/page.tsx`
    - `app/member/qnas/[id]/edit/page.tsx`

## 🖼️ 스크린샷 및 데모

(로직 수정으로 인한 동작 변경이므로, UI 변경 스크린샷은 해당되지 않으나, 수정 페이지 진입 시 제목 필드에 이전 값이 정상적으로 채워지는 것을 확인할 수 있습니다.)

## 👀 리뷰어

<!--- 이 PR의 리뷰를 요청할 담당자를 지정해주세요 -->
<!-- 예시: @username -->
@ (리뷰어_GitHub_ID)

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. (`fix(member): 게시물/질문 수정 시 제목 필드 초기값 설정 오류 해결`)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트). (수정 페이지 진입 시 제목 필드 확인)
- [ ] 필요한 경우 문서를 업데이트했습니다.
- [x] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [x] 브랜치가 최신 상태의 메인 브랜치와 병합 가능합니다.

## 📢 특이사항

<!--- 리뷰어가 알아야 할 주의사항이나 특이점이 있다면 여기에 작성해주세요 -->
없습니다.